### PR TITLE
fix bug in angle-vector-motion-plan

### DIFF
--- a/pr2eus_moveit/euslisp/robot-moveit.l
+++ b/pr2eus_moveit/euslisp/robot-moveit.l
@@ -566,7 +566,7 @@
                                (send-message self robot-interface :angle-vector av total-time ac))))
                        controller-table)
               ))
-        controller-actions (send self ctype))
+        (gethash ctype controller-table) (send self ctype))
 
        (if use-send-angle-vector
            (send* self :joint-trajectory-to-angle-vector-list move-arm traj args)


### PR DESCRIPTION
error occur when
(length controller-actions) != (length (send self ctype))
this case happens when you init robot-interface with
:default-controller,
but send av with :rarm-controller.